### PR TITLE
Wait for debugger on Activity creation (for selected processes)

### DIFF
--- a/app/src/main/assets/xposed_init
+++ b/app/src/main/assets/xposed_init
@@ -1,2 +1,3 @@
 tw.idv.palatis.xappdebug.xposed.HookMain
 tw.idv.palatis.xappdebug.xposed.HookSelf
+tw.idv.palatis.xappdebug.xposed.HookDebugger

--- a/app/src/main/java/tw/idv/palatis/xappdebug/xposed/HookDebugger.java
+++ b/app/src/main/java/tw/idv/palatis/xappdebug/xposed/HookDebugger.java
@@ -1,0 +1,41 @@
+package tw.idv.palatis.xappdebug.xposed;
+
+import static de.robv.android.xposed.XposedHelpers.findAndHookConstructor;
+import static tw.idv.palatis.xappdebug.BuildConfig.APPLICATION_ID;
+import static tw.idv.palatis.xappdebug.Constants.LOG_TAG;
+
+import android.os.Bundle;
+import android.os.Debug;
+import android.util.Log;
+
+import androidx.annotation.Keep;
+
+import de.robv.android.xposed.IXposedHookLoadPackage;
+import de.robv.android.xposed.XC_MethodHook;
+import de.robv.android.xposed.XposedBridge;
+import de.robv.android.xposed.callbacks.XC_LoadPackage;
+
+@Keep
+public class HookDebugger implements IXposedHookLoadPackage {
+    @Override
+    public void handleLoadPackage(final XC_LoadPackage.LoadPackageParam lpparam) throws Throwable {
+        if (APPLICATION_ID.equals(lpparam.packageName))
+            return;
+
+        _hookActivityConstructor(lpparam);
+    }
+
+    private void _hookActivityConstructor(XC_LoadPackage.LoadPackageParam lpparam) {
+        findAndHookConstructor(
+                "android.app.Activity",
+                lpparam.classLoader,
+                new XC_MethodHook() {
+                    @Override
+                    protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+                        XposedBridge.log(LOG_TAG + ": (" + lpparam.packageName + ") Waiting for a debugger...");
+                        Debug.waitForDebugger();
+                    }
+                }
+        );
+    }
+}


### PR DESCRIPTION
This PR add a functionality with a new XPosed hook.

The functionality aims at pause application at start (during the creation of any Activity object) so it is easier to attach a debugger and debug the very first instructions of the app.

This functionality is enabled only for processes selected for module injection in LSPosed (or the like).

To enable it:
1. Open the module page in LSPosed
2. Select any app (e.g. "Calculator")
3. Open XAppDebug
4. Select the app at step 2
5. Open the selected app
6. Now the app is waiting for the debugger at the splash screen